### PR TITLE
v.gsflow.grid/v.gsflow.grid.py

### DIFF
--- a/v.gsflow.grid/v.gsflow.grid.py
+++ b/v.gsflow.grid/v.gsflow.grid.py
@@ -118,7 +118,8 @@ def main():
     cols = colValues[:,colNames == 'col'].astype(int).squeeze()
     nrows = np.max(rows)
     ncols = np.max(cols)
-    _id = ncols*(rows-1) + cols
+    cats = np.ravel([cats])
+    _id = np.ravel([ncols*(rows-1) + cols])
     _id_cat = []
     for i in range(len(_id)):
       _id_cat.append( (_id[i], cats[i]) )

--- a/v.gsflow.hruparams/v.gsflow.hruparams.py
+++ b/v.gsflow.hruparams/v.gsflow.hruparams.py
@@ -30,6 +30,13 @@
 #%  keyword: GSFLOW
 #%end
 
+#%option G_OPT_R_INPUT
+#%  key: elevation
+#%  label: Elevation raster
+#%  required: yes
+#%  guidependency: layer,column
+#%end
+
 #%option G_OPT_V_INPUT
 #%  key: input
 #%  label: Sub-basins to become HRUs
@@ -96,6 +103,7 @@ def main():
     HRU = options['output']
     slope = options['slope']
     aspect = options['aspect']
+    elevation = options['elevation']
 
     ################################
     # CREATE HRUs FROM SUB-BASINS  #
@@ -205,7 +213,7 @@ def main():
 
     # SLOPE (and aspect) 
     #####################
-    v.rast_stats(map=HRU, raster='slope', method='average', column_prefix='tmp', flags='c', quiet=True)
+    v.rast_stats(map=HRU, raster=slope, method='average', column_prefix='tmp', flags='c', quiet=True)
     v.db_update(map=HRU, column='hru_slope', query_column='tmp_average', quiet=True)
 
     # ASPECT
@@ -215,8 +223,8 @@ def main():
     # average -- x- and y-vectors
     # Geographic coordinates, so sin=x, cos=y.... not that it matters so long 
     # as I am consistent in how I return to degrees
-    r.mapcalc('aspect_x = sin(aspect)', overwrite=True, quiet=True)
-    r.mapcalc('aspect_y = cos(aspect)', overwrite=True, quiet=True)
+    r.mapcalc('aspect_x = sin(' + aspect + ')', overwrite=gscript.overwrite(), quiet=True)
+    r.mapcalc('aspect_y = cos(' + aspect + ')', overwrite=gscript.overwrite(), quiet=True)
     #grass.run_command('v.db.addcolumn', map=HRU, columns='aspect_x_sum double precision, aspect_y_sum double precision, ncells_in_hru integer')
     v.rast_stats(map=HRU, raster='aspect_x', method='sum', column_prefix='aspect_x', flags='c', quiet=True)
     v.rast_stats(map=HRU, raster='aspect_y', method='sum', column_prefix='aspect_y', flags='c', quiet=True)
@@ -237,7 +245,7 @@ def main():
 
     # ELEVATION
     ############
-    v.rast_stats(map=HRU, raster='srtm', method='average', column_prefix='tmp', flags='c', quiet=True)
+    v.rast_stats(map=HRU, raster=elevation, method='average', column_prefix='tmp', flags='c', quiet=True)
     v.db_update(map=HRU, column='hru_elev', query_column='tmp_average', quiet=True)
     v.db_dropcolumn(map=HRU, columns='tmp_average', quiet=True)
 

--- a/v.gsflow.reaches/v.gsflow.reaches.py
+++ b/v.gsflow.reaches/v.gsflow.reaches.py
@@ -341,12 +341,12 @@ def main():
     v.db_update(map=reaches, column='SLOPE', value='(zr1 - zr2)/RCHLEN')
     v.db_update(map=reaches, column='SLOPE', value=Smin, where='SLOPE <= '+str(Smin))
 
-    # srtm_local_filled_grid = srtm_local_filled @ 200m (i.e. current grid)
-    #  resolution
-    # r.to.vect in=srtm_local_filled_grid out=srtm_local_filled_grid col=z type=area --o#
-    v.db_addcolumn(map=reaches, columns='z_topo_mean double precision')
-    v.what_vect(map=reaches, query_map='srtm_local_filled_grid', column='z_topo_mean', query_column='z')
-    v.db_update(map=reaches, column='STRTOP', value='z_topo_mean -'+str(h_stream))
+    ## srtm_local_filled_grid = srtm_local_filled @ 200m (i.e. current grid)
+    ##  resolution
+    ## r.to.vect in=srtm_local_filled_grid out=srtm_local_filled_grid col=z type=area --o#
+    #v.db_addcolumn(map=reaches, columns='z_topo_mean double precision')
+    #v.what_vect(map=reaches, query_map='srtm_local_filled_grid', column='z_topo_mean', query_column='z')
+    #v.db_update(map=reaches, column='STRTOP', value='z_topo_mean -'+str(h_stream))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
-- cats and _id were originally integer variables, but were being treated as
   iterable in the following for loop.  This problem was fixed by converting
   these two variables into length-1 numpy arrays.

v.gsflow.hruparams/v.gsflow.hruparams.py
-- Names for slope, aspect, and elevation rasters were originally hard-coded
   strings.  These strings have been replaced by variables declared during
   option parsing at the beginning of the script.

v.gsflow.reaches/v.gsflow.reaches.py
-- The name for the srtm_local_filled_grid raster was originally a hard-
   coded string in this script.  The section referring to this raster has been
   commented out pending changes to the references to this raster in
   reach_builder.py.